### PR TITLE
2.1.0: multistep normalisation fix + negative control bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![logo](docs/images/logo.png)
 
 [![Workflow checks](https://github.com/friendsofstrandseq/ashleys-qc-pipeline/actions/workflows/main.yaml/badge.svg)](https://github.com/friendsofstrandseq/ashleys-qc-pipeline/actions/workflows/main.yaml)
-[![Snakemake](https://img.shields.io/badge/snakemake-≥7.14.0-brightgreen.svg)](https://snakemake.github.io)
+[![Snakemake](https://img.shields.io/badge/snakemake-≥7.12.0-brightgreen.svg)](https://snakemake.github.io)
 
 ---
 

--- a/workflow/rules/gc.smk
+++ b/workflow/rules/gc.smk
@@ -90,7 +90,7 @@ if config["multistep_normalisation"] is True:
         output:
             "{folder}/{sample}/counts/multistep_normalisation/{sample}.txt.scaled.GC.VST.reformat.gz"
         conda:
-            "../envs/mc_base.yaml"
+            "../envs/ashleys_base.yaml"
         resources:
             mem_mb=get_mem_mb,
         script:


### PR DESCRIPTION
checkpoint mosaic count to automatically symlink/copy non-empty BAM files Add empty fastq files as neg control test